### PR TITLE
add missing dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -14,7 +14,7 @@ rpm -Uvh https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 sed -i 's/^mirrorlist=https/mirrorlist=http/g' /etc/yum.repos.d/epel.repo
 yum update -y
 
-yum --nogpgcheck install -y python python-devel git amqp python-pip libffi-devel openssl-devel gcc python-setuptools MySQL-python supervisor redis sshpass python-keyczar vim ansible-2.2.1.0
+yum --nogpgcheck install -y python python-devel git amqp python-pip libffi-devel openssl-devel gcc python-setuptools MySQL-python supervisor redis sshpass python-keyczar vim ansible-2.2.1.0 libyaml-devel make
 
 mkdir -p $COMPASS_DIR/compass
 touch $COMPASS_DIR/compass/__init__.py


### PR DESCRIPTION
* `make` is needed when [`pip install pynacl`](https://github.com/pyca/pynacl/issues/298#issuecomment-307656806);
* `libyaml-devel` is needed when `pip install pyyaml`;